### PR TITLE
feat(local): forward arbitrary headers on every request to Firefly III

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,25 @@ You can easily deploy this MCP server to Cloudflare Workers using the button bel
    npm run dev
    ```
 
+## Forwarding extra HTTP headers
+
+If your Firefly III instance sits behind an authentication proxy (Cloudflare Access, AWS API Gateway, Authelia, basic-auth, etc.), the proxy usually expects extra headers in addition to the Firefly Personal Access Token. You can ask the MCP server to forward arbitrary headers on every request via:
+
+| Method | Format |
+| --- | --- |
+| Env var | `FIREFLY_III_EXTRA_HEADERS='{"Header-Name":"value", ...}'` |
+| CLI arg | `--extraHeaders '{"Header-Name":"value", ...}'` |
+
+The value must be a JSON object whose values are strings; anything else is ignored with a warning. The `Authorization` header is reserved (the PAT is always sent there) and cannot be overridden via this mechanism. Header values are never logged — only the names are printed once at startup.
+
+### Example: Cloudflare Access
+
+```bash
+FIREFLY_III_EXTRA_HEADERS='{"CF-Access-Client-Id":"xxxxxxxx.access","CF-Access-Client-Secret":"yyyyyyyy"}'
+```
+
+This causes every request to Firefly III to include both the service token headers and the regular `Authorization: Bearer <PAT>`, so the request passes the Cloudflare Access policy and authenticates against Firefly.
+
 ## Tool Filtering Options
 
 You can filter which tools are exposed to the MCP client to reduce token usage and focus on specific functionality:

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -85,7 +85,15 @@ export const executeApiTool = async (
   /**
    * Used Preloaded Security Schemes, ignored for now
    */
-  const { pat, baseUrl } = serverConfig;
+  const { pat, baseUrl, extraHeaders } = serverConfig;
+  // Apply user-provided extra headers (e.g. for an auth proxy in front of Firefly III).
+  // Authorization is reserved so the Bearer PAT cannot be overridden.
+  if (extraHeaders) {
+    for (const [key, value] of Object.entries(extraHeaders)) {
+      if (key.toLowerCase() === 'authorization') continue;
+      headers[key] = value;
+    }
+  }
   headers['Authorization'] = `Bearer ${pat}`;
 
   // Construct the full URL
@@ -93,8 +101,9 @@ export const executeApiTool = async (
   const requestUrl = queryParams ? `${requestEndpoint}?${new URLSearchParams(queryParams).toString()}` : requestEndpoint;
   const requestMethod = definition.method.toUpperCase();
 
-  // Log request info to stderr (doesn't affect MCP output)
-  console.debug(`Executing tool "${toolName}": ${requestMethod} ${requestEndpoint}`);
+  // Log request info to stderr. console.debug actually writes to stdout in Node,
+  // which corrupts the MCP JSON-RPC frames carried over stdout.
+  console.error(`Executing tool "${toolName}": ${requestMethod} ${requestEndpoint}`);
 
   const response = await fetch(requestUrl, {
     method: definition.method.toUpperCase(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,6 +10,8 @@ export type McpServerConfig = {
   baseUrl: string;
   pat: string;
   enableToolTags?: string[];
+  /** Optional extra headers to send on every request to Firefly III (e.g. when sitting behind an auth proxy). The "Authorization" header is reserved and cannot be overridden. */
+  extraHeaders?: Record<string, string>;
 }
 
 /** 

--- a/packages/local/src/app.ts
+++ b/packages/local/src/app.ts
@@ -33,7 +33,31 @@ export class FireflyIIIMcpServer {
     const pat = patArgIndex !== -1 ? process.argv[patArgIndex + 1] : process.env.FIREFLY_III_PAT;
     const baseUrlArgIndex = process.argv.indexOf('--baseUrl');
     const baseUrl = baseUrlArgIndex !== -1 ? process.argv[baseUrlArgIndex + 1] : process.env.FIREFLY_III_BASE_URL;
-    
+
+    // Optional extra headers to forward on every request (e.g. when Firefly III sits behind
+    // an authentication proxy such as Cloudflare Access, AWS API Gateway, Authelia, etc.).
+    // Env var takes precedence over the CLI arg. Expected format: a JSON object of strings.
+    const extraHeadersArgIndex = process.argv.indexOf('--extraHeaders');
+    const extraHeadersRaw = process.env.FIREFLY_III_EXTRA_HEADERS
+      ?? (extraHeadersArgIndex !== -1 ? process.argv[extraHeadersArgIndex + 1] : undefined);
+    let extraHeaders: Record<string, string> | undefined;
+    if (extraHeadersRaw) {
+      try {
+        const parsed = JSON.parse(extraHeadersRaw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          extraHeaders = Object.fromEntries(
+            Object.entries(parsed)
+              .filter(([, v]) => typeof v === 'string')
+              .map(([k, v]) => [k, v as string])
+          );
+        } else {
+          console.warn('Warning: FIREFLY_III_EXTRA_HEADERS must be a JSON object of string values. Ignoring.');
+        }
+      } catch (e) {
+        console.warn(`Warning: Could not parse FIREFLY_III_EXTRA_HEADERS as JSON. Ignoring. (${(e as Error).message})`);
+      }
+    }
+
     // Get preset and tools arguments
     const presetArgIndex = process.argv.indexOf('--preset');
     const toolsArgIndex = process.argv.indexOf('--tools');
@@ -82,6 +106,7 @@ export class FireflyIIIMcpServer {
       console.error('  FIREFLY_III_BASE_URL: Firefly III instance URL');
       console.error('  FIREFLY_III_PRESET: Optional preset name');
       console.error('  FIREFLY_III_TOOLS: Optional comma-separated list of tool tags');
+      console.error('  FIREFLY_III_EXTRA_HEADERS: Optional JSON object with extra headers to forward on every request');
       console.error(`\nAvailable presets: ${getAvailablePresets().join(', ')}`);
       console.error(`Available tool tags: ${ALL_TOOL_TAGS.join(', ')}`);
       process.exit(1);
@@ -92,6 +117,7 @@ export class FireflyIIIMcpServer {
       pat,
       baseUrl,
       enableToolTags,
+      extraHeaders,
     };
 
     // Get server
@@ -118,15 +144,20 @@ export class FireflyIIIMcpServer {
     const transport = new StdioServerTransport();
     await this.server.connect(transport);
 
-    // Log server info
-    console.log(`[Firefly III MCP Server] Server running locally on stdio`);
-    console.log(`[Firefly III MCP Server] Connected to Firefly III at: ${this.serverConfig.baseUrl}`);
-    
+    // Log server info to stderr — stdout is reserved for MCP JSON-RPC framing.
+    console.error(`[Firefly III MCP Server] Server running locally on stdio`);
+    console.error(`[Firefly III MCP Server] Connected to Firefly III at: ${this.serverConfig.baseUrl}`);
+
+    // Log extra header names (values are never logged)
+    if (this.serverConfig.extraHeaders && Object.keys(this.serverConfig.extraHeaders).length > 0) {
+      console.error(`[Firefly III MCP Server] Extra headers configured: ${Object.keys(this.serverConfig.extraHeaders).join(', ')} (values not logged)`);
+    }
+
     // Log enabled tool tags if specified
     if (this.serverConfig.enableToolTags) {
-      console.log(`[Firefly III MCP Server] Enabled tool tags: ${this.serverConfig.enableToolTags.join(', ')}`);
+      console.error(`[Firefly III MCP Server] Enabled tool tags: ${this.serverConfig.enableToolTags.join(', ')}`);
     } else {
-      console.log(`[Firefly III MCP Server] Using default tool tags`);
+      console.error(`[Firefly III MCP Server] Using default tool tags`);
     }
   }
 }


### PR DESCRIPTION
When Firefly III sits behind an authentication proxy (e.g. Cloudflare Access, AWS API Gateway, Authelia, a basic-auth reverse proxy), the proxy usually expects extra headers on top of the Firefly Personal Access Token. This adds an optional, opt-in mechanism to forward such headers without coupling the MCP server to any specific provider.

Configuration (env var takes precedence over the CLI arg):
  FIREFLY_III_EXTRA_HEADERS='{"Header":"value", ...}'
  --extraHeaders '{"Header":"value", ...}'

The value must be a JSON object of string values; otherwise it is ignored with a warning. The "Authorization" header is reserved (the PAT is always sent there) and cannot be overridden through this mechanism. Header values are never logged — only the names are printed once at startup.

Behavior is identical to the current upstream when the env var / arg is not provided.